### PR TITLE
Fix deprecated set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - id: get-version
         run: |
           parsedVersion=$(echo ${{ github.ref }} | cut -dv -f2)
-          echo "::set-output name=version::$parsedVersion"
+          echo "name=$parsedVersion" >> "$GITHUB_OUTPUT"
       - name: Publish BicepDocs
         run: dotnet publish --configuration release --self-contained true -p:AssemblyVersion=${{ steps.get-version.outputs.version }} -p:Version=${{ steps.get-version.outputs.version }} -p:PublishTrimmed=true -p:PublishSingleFile=true -p:TrimmerDefaultAction=copyused -p:SuppressTrimAnalysisWarnings=true -r ${{ matrix.rid }} ./src/BicepDocs.Cli/BicepDocs.Cli.csproj
       - name: Rename binary


### PR DESCRIPTION
**What changes does this pull request introduce?**

- Fixed the deprecated `set-output` command 

**Is there anything specific the reviewers should keep in mind when reviewing this pull request?**

No

- [X] I agree that by publishing this pull request I am submitting my own code that I have the rights to use and implement. I also assign full ownership of the code over to the `bicepdocs` maintainers under the MIT license.

**Please check the appropriate options:**

- [X] I have read the [contributing guidelines](https://github.com/joachimdalen/bicepdocs/blob/main/CONTRIBUTING.md).
- [X] I have updated the relevant documentation.
- [X] Latest version of `main` is merged into my branch.
